### PR TITLE
Fix confusing comment on `M.library_end` use in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ let main () =
   print_rows res; (* see below *)
   M.Stmt.close stmt |> or_die;
   M.close mariadb;
-  (* Call this only once, before you're done using all
+  (* Call this only once, after you're done using all
      your database handles. *)
   M.library_end ()
 


### PR DESCRIPTION
Unless I'm misunderstanding how to use `M.library_end`, I think this is what's actually meant.